### PR TITLE
fix: display menu pictures on mobile

### DIFF
--- a/assets/sass/menuPage.scss
+++ b/assets/sass/menuPage.scss
@@ -104,7 +104,18 @@
     margin: 0 15px;
     > div {
       display: flex;
+      flex-direction: column;
+      align-items: center;
       width: 100%;
+      margin-top: 10px;
+    }
+
+    .picturesContainer > div {
+      margin: 10px;
+    }
+
+    .pictureContainer div {
+      margin-top: 10px;
     }
 
     h2 {

--- a/src/app/carte/page.tsx
+++ b/src/app/carte/page.tsx
@@ -33,9 +33,13 @@ const MenuPage = () => {
               ))}
             </ul>
           </div>
-          {menuItem.picture && size.width > 768 && (
+          {menuItem.picture && (
             <div
-              className={menuItem.picture.length > 1 ? "picturesContainer" : ""}
+              className={
+                menuItem.picture.length > 1
+                  ? "picturesContainer"
+                  : "pictureContainer"
+              }
             >
               {menuItem.picture.map((picture) => (
                 <div key={picture.description}>


### PR DESCRIPTION

# 🩺 Problème
Les clients ont besoin de visualiser les photos des plats sur leur mobile

# 💊 Proposition
Affichage des photos en version mobile

# ✅ Checklist

- [ ] Ajout de tests unitaires
- [ ] Self-review du code
- [ ] Revue Sonarcloud (fix errors & warnings)
- [ ] Vérifier l'accessibilité (si frontend)
- [ ] Ecrire et assigner la tâche de validation (tests fonctionnels) à quelqu'un du Produit (juste avant de merge la PR)
