### PR TITLE
feat: refacto dashboard behavior

### DIFF
--- a/src/components/dashboard/modal-dashboard/cancel-modal-dashboard.component.tsx
+++ b/src/components/dashboard/modal-dashboard/cancel-modal-dashboard.component.tsx
@@ -1,41 +1,41 @@
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import Modal, { TModalProps } from "./modal.component";
 import ButtonForm from "src/components/form/form-fields/button/button-form.component";
 
-export type TCreateModalProps = Pick<
-  TModalProps,
-  "closeModal" | "modalHeaderTitle"
-> & {
-  displayModal: boolean;
+export type TCreateModalProps = Pick<TModalProps, "modalHeaderTitle"> & {
   handleDeleteItem: VoidFunction;
+  isDeleteModal: string;
+  isCloseModal: Dispatch<SetStateAction<string>>;
 };
 
 const CancelModalDashboard = ({
-  displayModal,
-  closeModal,
+  isCloseModal,
   modalHeaderTitle,
+  isDeleteModal,
   handleDeleteItem,
 }: TCreateModalProps) => {
-  if (!displayModal) return null;
+  if (!isDeleteModal) return null;
 
   return (
-    <Modal
-      isCancelModal={true}
-      closeModal={closeModal}
-      modalHeaderTitle={modalHeaderTitle}
-    >
-      <div className="cancel-content-modal-container">
-        <p>Etes-vous sur de vouloir supprimer cet article ?</p>
-        <div>
-          <ButtonForm colorButton="neutral" onClick={closeModal}>
-            Non, merci
-          </ButtonForm>
-          <ButtonForm colorButton="alert" onClick={handleDeleteItem}>
-            Oui, je suis sur
-          </ButtonForm>
+    isDeleteModal && (
+      <Modal
+        isCancelModal={true}
+        closeModal={isCloseModal}
+        modalHeaderTitle={modalHeaderTitle}
+      >
+        <div className="cancel-content-modal-container">
+          <p>Etes-vous sur de vouloir supprimer cet article ?</p>
+          <div>
+            <ButtonForm colorButton="neutral" onClick={() => isCloseModal("")}>
+              Non, merci
+            </ButtonForm>
+            <ButtonForm colorButton="alert" onClick={handleDeleteItem}>
+              Oui, je suis sur
+            </ButtonForm>
+          </div>
         </div>
-      </div>
-    </Modal>
+      </Modal>
+    )
   );
 };
 

--- a/src/components/dashboard/modal-dashboard/create-modal-dashboard.component.tsx
+++ b/src/components/dashboard/modal-dashboard/create-modal-dashboard.component.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { Dispatch, SetStateAction } from "react";
 import Modal, { TModalProps } from "./modal.component";
 import FormRoot from "src/components/form/form-root.component";
 import FormItems from "src/components/form/form-items.component";
@@ -7,42 +7,45 @@ import { TFields } from "src/components/form/form";
 
 export type TCreateModalProps = Pick<
   TModalProps,
-  "closeModal" | "modalHeaderTitle"
+  "modalHeaderTitle"
 > & {
   modalFields: TFields[];
-  displayModal: boolean;
-  isEditModal?: boolean;
-  handleAction: (formData: FormData) => void;
+  isCreateEditModal: string;
+  handleCreateEditAction: (formData: FormData) => void;
+  isCloseModal: Dispatch<SetStateAction<string>>
 };
 
 const CreateModalDashboard = ({
   modalFields,
-  displayModal,
-  closeModal,
+  isCloseModal,
   modalHeaderTitle,
-  isEditModal,
-  handleAction,
+  handleCreateEditAction,
+  isCreateEditModal,
 }: TCreateModalProps) => {
-  if (!displayModal) return null;
+  if (!isCreateEditModal) return null;
 
   return (
-    <Modal closeModal={closeModal} modalHeaderTitle={modalHeaderTitle}>
-      <FormRoot handleAction={handleAction} isModalForm={true}>
-        <FormItems fieldItems={modalFields} />
-        <div className="buttons-action-modal-container">
-          <ButtonForm
-            type={"submit"}
-            children={isEditModal ? "Modifier" : "Ajouter"}
-          />
-          <ButtonForm
-            type={"button"}
-            children="Annuler"
-            onClick={closeModal}
-            colorButton="alert"
-          />
-        </div>
-      </FormRoot>
-    </Modal>
+    isCreateEditModal && (
+      <Modal closeModal={isCloseModal} modalHeaderTitle={modalHeaderTitle}>
+        <FormRoot handleAction={handleCreateEditAction} isModalForm={true}>
+          <FormItems fieldItems={modalFields} />
+          <div className="buttons-action-modal-container">
+            <ButtonForm
+              type={"submit"}
+              children={
+                isCreateEditModal === "editModal" ? "Modifier" : "Ajouter"
+              }
+            />
+            <ButtonForm
+              type={"button"}
+              children="Annuler"
+              onClick={() => isCloseModal("")}
+              colorButton="alert"
+            />
+          </div>
+        </FormRoot>
+      </Modal>
+    )
   );
 };
 

--- a/src/components/dashboard/modal-dashboard/modal.component.tsx
+++ b/src/components/dashboard/modal-dashboard/modal.component.tsx
@@ -1,11 +1,11 @@
-import React, { ReactNode, useRef } from "react";
+import React, { Dispatch, ReactNode, SetStateAction, useRef } from "react";
 import { TrashIcon, XMarkIcon } from "@heroicons/react/24/solid";
 import { UseClickOutside } from "src/hooks/use-click-outside";
 import ButtonForm from "src/components/form/form-fields/button/button-form.component";
 
 export type TModalProps = {
   children: ReactNode;
-  closeModal: () => void;
+  closeModal: Dispatch<SetStateAction<string>>;
   modalHeaderTitle?: string;
   isCancelModal?: boolean;
 };
@@ -18,7 +18,11 @@ const Modal = ({
 }: TModalProps) => {
   const modalRef = useRef(null);
 
-  UseClickOutside({ ref: modalRef, callBack: closeModal });
+  const handleCloseModal = () => {
+    closeModal("");
+  };
+
+  UseClickOutside({ ref: modalRef, callBack: handleCloseModal });
   return (
     <div className="modal-container">
       <div>
@@ -30,7 +34,7 @@ const Modal = ({
         >
           <div className="modal-header-container">
             <h3>{modalHeaderTitle}</h3>
-            <ButtonForm hasIconButton={true} onClick={closeModal}>
+            <ButtonForm hasIconButton={true} onClick={handleCloseModal}>
               <XMarkIcon />
             </ButtonForm>
             {isCancelModal && (

--- a/src/components/dashboard/table-dashboard.component.tsx
+++ b/src/components/dashboard/table-dashboard.component.tsx
@@ -1,39 +1,117 @@
 "use client";
-import React from "react";
+import React, { Dispatch, SetStateAction, useEffect, useState } from "react";
 import TableRoot from "../table/table-root.component";
 import TableHeader from "../table/table-header.component";
 import ButtonForm from "../form/form-fields/button/button-form.component";
 import Table, { TTableProps } from "../table/table.component";
+import CreateModalDashboard from "./modal-dashboard/create-modal-dashboard.component";
+import CancelModalDashboard from "./modal-dashboard/cancel-modal-dashboard.component";
+import { TFields } from "../form/form";
+import DropdownButton from "../form/form-fields/dropdown-button/dropdown-button.component";
+import { useTitle } from "src/utils/string-formatter";
 
 export type TTableDashboardProps = {
-  dashboardTitle?: string;
+  title: string;
+  fields: TFields[];
   selectedItem: (value: any) => void;
-  handleAction: (value: string) => void;
+  handleCreatEditModalFormAction: (formData: FormData) => void;
+  handleDeleteModalAction: () => void;
+  setModalActionForm: Dispatch<SetStateAction<string>>;
+  modalActionForm: string;
 };
 
 const TableDashboard = <T, K extends keyof T>({
   data,
   columns,
-  dashboardTitle,
+  fields,
+  title,
   selectedItem,
-  handleAction,
+  handleCreatEditModalFormAction,
+  handleDeleteModalAction,
+  setModalActionForm,
+  modalActionForm,
 }: TTableProps<T, K> & TTableDashboardProps) => {
+  const [displayModal, setDisplayModal] = useState("");
+  const [isCreateEditModal, setIsCreateEditModal] = useState("");
+  const [isDeleteModal, setIsDeleteModal] = useState("");
+
+  useEffect(() => {
+    if (displayModal === "createModal" || displayModal === "editModal") {
+      setIsCreateEditModal(displayModal);
+      setModalActionForm(displayModal);
+      setDisplayModal("");
+    }
+
+    if (displayModal === "deleteModal") {
+      setIsDeleteModal(displayModal);
+      setModalActionForm(displayModal);
+      setDisplayModal("");
+    }
+  }, [displayModal]);
+
+  useEffect(() => {
+    if (modalActionForm === "") {
+      setIsCreateEditModal("");
+      setIsDeleteModal("");
+    }
+  }, [modalActionForm]);
+
+  const dataRows = data.map((value) => ({
+    ...value,
+    actions: (
+      <DropdownButton
+        listItems={[
+          {
+            content: "Modifier",
+            onClickAction: () => setDisplayModal("editModal"),
+          },
+          {
+            content: "Supprimer",
+            onClickAction: () => setDisplayModal("deleteModal"),
+          },
+        ]}
+        type="button"
+        hasIconButton={true}
+      />
+    ),
+  }));
+
   return (
     <div>
-      <h1>{dashboardTitle}</h1>
+      <h1>{title}</h1>
       <TableRoot>
         <TableHeader>
-          <ButtonForm type="button" onClick={() => handleAction("openModal")}>
+          <ButtonForm
+            type="button"
+            onClick={() => setDisplayModal("createModal")}
+          >
             Ajouter
           </ButtonForm>
         </TableHeader>
         <Table
           selectedItem={selectedItem}
           columns={columns}
-          data={data}
-          handleAction={handleAction}
+          data={dataRows}
+          handleAction={() => setDisplayModal("editModal")}
         />
       </TableRoot>
+
+      <CreateModalDashboard
+        modalFields={fields}
+        isCreateEditModal={isCreateEditModal}
+        isCloseModal={setIsCreateEditModal}
+        handleCreateEditAction={handleCreatEditModalFormAction}
+        modalHeaderTitle={
+          isCreateEditModal === "createModal"
+            ? `Ajouter une ${useTitle(title)}`
+            : `Modifier une ${useTitle(title)}`
+        }
+      />
+      <CancelModalDashboard
+        isCloseModal={setIsDeleteModal}
+        isDeleteModal={isDeleteModal}
+        handleDeleteItem={handleDeleteModalAction}
+      />
     </div>
   );
 };

--- a/src/components/form/form-fields/input/input-form.component.tsx
+++ b/src/components/form/form-fields/input/input-form.component.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useId, useState } from "react";
+import React, { forwardRef, useEffect, useId, useState } from "react";
 import { TFieldItem, TInputForm } from "../../form";
 import LabelForm from "../../common/label-form.component";
 import ErrorMessage from "../../common/error-message.component";
@@ -23,6 +23,14 @@ const InputForm = forwardRef<
   ) => {
     const [inputDefaultValue, setInputDefaultValue] = useState(defaultValue);
     const id = useId();
+
+    useEffect(() => {
+      if (defaultValue) {
+        setInputDefaultValue(defaultValue);
+      } else {
+        setInputDefaultValue("");
+      }
+    }, [defaultValue]);
 
     return (
       <div className="input-container">

--- a/src/components/table/table.component.tsx
+++ b/src/components/table/table.component.tsx
@@ -5,7 +5,7 @@ import React, { ReactNode } from "react";
 export type TTableProps<T, K extends keyof T> = {
   columns: Array<TColumnDefinitionType<T, K>>;
   data: Array<T>;
-  selectedItem: (value: any) => void;
+  selectedItem: (value: T) => void;
   handleAction: (value: any) => void;
 };
 

--- a/src/utils/string-formatter.ts
+++ b/src/utils/string-formatter.ts
@@ -1,0 +1,4 @@
+export const useTitle = (value: string) => {
+  const index = value.indexOf(" ");
+  return value.toLowerCase().substring(index, value.length - 1);
+};


### PR DESCRIPTION
# 🩺 Problème

- Les pages créées génèrent beaucoup trop de répétitions (boîte de dialogue, props...)

# 💊 Proposition
- Création d'un composant table dashboard qui va prendre tout les comportements côté client, pour aussi récupérer les données en props afin de séparer les actions côté serveur

# ✅ Checklist

- [ ] Ajout de tests unitaires
- [ ] Self-review du code
- [ ] Revue Sonarcloud (fix errors & warnings)
- [ ] Vérifier l'accessibilité (si frontend)
- [ ] Ecrire et assigner la tâche de validation (tests fonctionnels) à quelqu'un du Produit (juste avant de merge la PR)
