### PR TITLE
fix: move toast to bottom & add overflow-x to hidden

### DIFF
--- a/assets/sass/body.scss
+++ b/assets/sass/body.scss
@@ -106,6 +106,7 @@ section {
   display: block;
 }
 body {
+  overflow-x: hidden;
   line-height: 1;
 }
 ol,

--- a/assets/sass/toast/toast.scss
+++ b/assets/sass/toast/toast.scss
@@ -1,6 +1,6 @@
 .toast-container {
   position: absolute;
-  top: 0;
+  bottom: 0;
   right: 15px;
   display: flex;
   align-items: center;


### PR DESCRIPTION

# 🩺 Problème
Le toast n'apparait pas lorsque le table dépasse le viewport et le toast affiche le barre de scroll de l'axe x lorsqu'il disparait


# ✅ Checklist

- [ ] Ajout de tests unitaires
- [ ] Self-review du code
- [ ] Revue Sonarcloud (fix errors & warnings)
- [ ] Vérifier l'accessibilité (si frontend)
- [ ] Ecrire et assigner la tâche de validation (tests fonctionnels) à quelqu'un du Produit (juste avant de merge la PR)
