### PR TITLE
feat: refacto dashboard layout

### DIFF
--- a/src/app/admin/dashboard/layout.tsx
+++ b/src/app/admin/dashboard/layout.tsx
@@ -1,28 +1,26 @@
-"use client";
-import { RocketLaunchIcon } from "@heroicons/react/24/solid";
+import { FaceSmileIcon, HeartIcon } from "@heroicons/react/24/solid";
 import React from "react";
-import DashboardSidebar, {
-  TSidebarItems,
-} from "src/components/dashboard/dashboard-sidebar/dashboard-sidebar.component";
-import { ToastProvider } from "../providers/toast.provider";
+import DashboardSidebar from "src/components/dashboard/dashboard-sidebar/dashboard-sidebar.component";
+import { getAllDishServices } from "../actions/dishs-service/dish-services.actions";
+import { ToastProvider } from "src/app/admin/providers/toast-client.provider";
 
 type TDashboardLayout = {
   children: React.ReactNode;
 };
 
-const DashboardLayout = ({ children }: TDashboardLayout) => {
-  const sidebarItems: Array<TSidebarItems> = [
-    {
-      content: "Entrées",
-      path: "/admin/dashboard/starters",
-      icon: <RocketLaunchIcon />,
-    },
-    {
-      content: "Soupes",
-      path: "/admin/dashboard/soup",
-      icon: <RocketLaunchIcon />,
-    },
-  ];
+const DashboardLayout = async ({ children }: TDashboardLayout) => {
+  const dishServices = await getAllDishServices();
+
+  if (!dishServices) return <div>Chargement...</div>;
+
+  const sidebarItems = dishServices.map((dishService, index) => {
+    let alternateIcon = index % 2;
+    return {
+      content: dishService.title,
+      path: `/admin/dashboard/${dishService.title}`,
+      icon: alternateIcon === 0 ? <FaceSmileIcon /> : <HeartIcon />,
+    };
+  });
   return (
     <ToastProvider>
       <div className="dashboard-layout">

--- a/src/app/admin/providers/toast-client.provider.ts
+++ b/src/app/admin/providers/toast-client.provider.ts
@@ -1,0 +1,2 @@
+"use client";
+export { ToastProvider } from "../providers/toast.provider";


### PR DESCRIPTION

# 🩺 Problème
La liste des items à afficher dans la sidebar risque d'être longue (entrée, soupe, différents plats...)

# 💊 Proposition
- Utilisation d'une méthode getAll de prisma pour récupérer les titres du model dishService afin de créer une sidebar dynamique.
- Ce layout étant côté serveur, ajout d'un ToastClientProvider

# ✅ Checklist

- [ ] Ajout de tests unitaires
- [ ] Self-review du code
- [ ] Revue Sonarcloud (fix errors & warnings)
- [ ] Vérifier l'accessibilité (si frontend)
- [ ] Ecrire et assigner la tâche de validation (tests fonctionnels) à quelqu'un du Produit (juste avant de merge la PR)
