### PR TITLE
fix: replace defaultLocale value

### DIFF
--- a/assets/sass/body.scss
+++ b/assets/sass/body.scss
@@ -128,3 +128,10 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+
+body:has(.modalIsOpen) {
+  overflow: hidden;
+  header {
+    opacity: 0.7;
+  }
+}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -4,9 +4,11 @@ import { getRequestConfig } from "next-intl/server";
 // Can be imported from a shared config
 const locales = ["fr", "en"];
 
-export default getRequestConfig(async ({ locale }) => {
+export default getRequestConfig(async ({ requestLocale }) => {
+  let locale = await requestLocale;
+
   // Validate that the incoming `locale` parameter is valid
-  if (!locales.includes(locale as any)) notFound();
+  if (!locale || !locales.includes(locale as any)) notFound();
 
   return {
     messages: {

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -1,0 +1,19 @@
+import { getRequestConfig } from "next-intl/server";
+import { routing } from "./routing";
+
+export default getRequestConfig(async ({ requestLocale }) => {
+  // This typically corresponds to the `[locale]` segment.
+  let locale = await requestLocale;
+
+  // Validate that the incoming `locale` parameter is valid
+  if (!locale || !routing.locales.includes(locale as any)) {
+    locale = routing.defaultLocale;
+  }
+
+  return {
+    messages: {
+      ...(await import(`../../messages/${locale}/${locale}.json`)).default,
+      ...(await import(`../../messages/${locale}/menu.json`)).default,
+    },
+  };
+});

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,0 +1,8 @@
+import { defineRouting } from "next-intl/routing";
+
+export const routing = defineRouting({
+  // A list of all locales that are supported
+  locales: ["fr", "en"],
+
+  defaultLocale: "fr",
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,9 +1,9 @@
 import createIntlMiddleware from "next-intl/middleware";
 import { pathnames, localePrefix } from "./navigation";
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest } from "next/server";
 
 export default async function middleware(request: NextRequest) {
-  const defaultLocale = "fr";
+  const defaultLocale = request.cookies.get("NEXT_LOCALE")?.value || "fr";
 
   const handleI18nRouting = createIntlMiddleware({
     locales: ["fr", "en"],


### PR DESCRIPTION
# 🩺 Problème
1. Lorsque l'on se rend sur un page en FR, on modifie la langue en EN, on reclique sur une page est la langue repasse en FR
2. L'opacité de la modale à l'ouverture du site n'est plus présente
3. Nouvelle mise à jour suite à un changement de version de next-intl

# 💊 Proposition
1. Modification du middleware
2. Rajout de la condition CSS dans le body
3. Misa à jour selon la doc : https://next-intl.dev/blog/next-intl-3-22#await-request-locale

# ✅ Checklist

- [ ] Ajout de tests unitaires
- [ ] Self-review du code
- [ ] Revue Sonarcloud (fix errors & warnings)
- [ ] Vérifier l'accessibilité (si frontend)
- [ ] Ecrire et assigner la tâche de validation (tests fonctionnels) à quelqu'un du Produit (juste avant de merge la PR)
