### PR TITLE
feat: allow to click on phone number

### DIFF
--- a/assets/sass/contactPage.scss
+++ b/assets/sass/contactPage.scss
@@ -64,6 +64,11 @@
     margin-bottom: 20px;
   }
 
+  section:first-child a {
+    border: none;
+    background-color: transparent;
+  }
+
   section:last-child {
     position: relative;
     display: flex;
@@ -80,7 +85,7 @@
     border-top-right-radius: 50px;
   }
 
-  a {
+  section:last-child a {
     position: absolute;
     border-radius: 50px;
     border: none;
@@ -93,7 +98,7 @@
     text-decoration: none;
   }
 
-  a:hover {
+  section:last-child a:hover {
     background-color: $red-900;
     color: white;
   }

--- a/assets/sass/footer.scss
+++ b/assets/sass/footer.scss
@@ -30,6 +30,10 @@
     font-size: 1.8rem;
   }
 
+  > div:first-child > div:first-child a {
+    color: #fff;
+  }
+
   > div:first-child > div:nth-child(2) {
     align-items: center;
     border-left: 0.5px solid white;

--- a/assets/sass/menuPage.scss
+++ b/assets/sass/menuPage.scss
@@ -183,3 +183,46 @@
     }
   }
 }
+/*
+Click To Call anchor
+*/
+.click-to-call-container {
+  z-index: 3;
+  position: fixed;
+  right: 0;
+  top: 200px;
+  border: 1px solid $red-900;
+  border-radius: 0.5rem;
+  font-weight: $font-medium;
+  font-size: $text-sm;
+  padding: 0.625rem 1.25rem;
+  text-align: center;
+  margin-inline-end: 0.5rem;
+  margin-bottom: 0.5rem;
+  background-color: $red-900;
+  transition: background-color 0.3s ease;
+  transition: color 0.3s ease;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+.click-to-call-container svg {
+  width: 25px;
+  height: 25px;
+}
+
+.click-to-call-container:hover {
+  background-color: $red-800;
+}
+
+.click-to-call-container span {
+  margin: 0 0.7rem;
+}
+
+@media (max-width: 768px) {
+  .click-to-call-container {
+    top: 65px;
+  }
+}

--- a/messages/en/menu.json
+++ b/messages/en/menu.json
@@ -147,6 +147,7 @@
         "cocoJuice": "Coconut juice"
       },
       "supplement": "* Served w/ Jasmine rice"
-    }
+    },
+    "clickToCall": "Call"
   }
 }

--- a/messages/fr/menu.json
+++ b/messages/fr/menu.json
@@ -147,6 +147,7 @@
         "cocoJuice": "Jus de coco"
       },
       "supplement": "* Servis avec du riz nature"
-    }
+    },
+    "clickToCall": "Appeler"
   }
 }

--- a/src/app/[locale]/carte/layout.tsx
+++ b/src/app/[locale]/carte/layout.tsx
@@ -1,0 +1,20 @@
+"use client";
+import { PhoneIcon } from "@heroicons/react/24/solid";
+import React, { ReactNode } from "react";
+import { useTranslations } from "next-intl";
+
+const LayoutMenu = ({ children }: { children: ReactNode }) => {
+  const t = useTranslations("MenuPage");
+
+  return (
+    <>
+      <a className="click-to-call-container" href="tel:+33 1 43 36 05 16">
+        <PhoneIcon />
+        <span>{t("clickToCall")}</span>
+      </a>
+      {children}
+    </>
+  );
+};
+
+export default LayoutMenu;

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -26,7 +26,7 @@ const ContactPage = () => {
             <span>{t("restaurantName")}</span>
             <span>9 rue du Champ de l'Aloutette</span>
             <span>75013 Paris</span>
-            <Link href={""}>+33 1 43 36 05 16</Link>
+            <a href="tel:+33 1 43 36 05 16">01 43 36 05 16</a>
           </div>
         </div>
         <div>

--- a/src/app/[locale]/contact/page.tsx
+++ b/src/app/[locale]/contact/page.tsx
@@ -26,7 +26,7 @@ const ContactPage = () => {
             <span>{t("restaurantName")}</span>
             <span>9 rue du Champ de l'Aloutette</span>
             <span>75013 Paris</span>
-            <span>+33 1 43 36 05 16</span>
+            <Link href={""}>+33 1 43 36 05 16</Link>
           </div>
         </div>
         <div>

--- a/src/components/layout/footer.component.tsx
+++ b/src/components/layout/footer.component.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 import React from "react";
 import { merriweather } from "src/utils/font";
 
@@ -15,7 +16,7 @@ const FooterComponent = () => {
           <div>
             <span>9 rue du Champ de l'Aloutette</span>
             <span>75013 Paris</span>
-            <span>+33 1 43 36 05 16</span>
+            <a href="tel:+33 1 43 36 05 16">01 43 36 05 16</a>
           </div>
         </div>
         <div>

--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -1,5 +1,4 @@
 import { useTranslations } from "next-intl";
-import Link from "next/link";
 import CloseIcon from "public/assets/icons/close-icon";
 import { useRef } from "react";
 import { UseClickOutside } from "src/hooks/use-click-outside";
@@ -27,9 +26,7 @@ const ModalComponent = ({ isOpen, toggle }: TModalComponentProps) => {
           <h2>{t("takeAway")}</h2>
           <p>
             {t.rich("mainParagraph", {
-              spanLines: (chunks) => (
-                <Link href={`tel:+${chunks}`}>{chunks}</Link>
-              ),
+              spanLines: (chunks) => <a href={`tel:+${chunks}`}>{chunks}</a>,
             })}
           </p>
           <div>{t("visaAccepted")}</div>

--- a/src/components/modal/modal.component.tsx
+++ b/src/components/modal/modal.component.tsx
@@ -1,4 +1,5 @@
 import { useTranslations } from "next-intl";
+import Link from "next/link";
 import CloseIcon from "public/assets/icons/close-icon";
 import { useRef } from "react";
 import { UseClickOutside } from "src/hooks/use-click-outside";
@@ -26,7 +27,9 @@ const ModalComponent = ({ isOpen, toggle }: TModalComponentProps) => {
           <h2>{t("takeAway")}</h2>
           <p>
             {t.rich("mainParagraph", {
-              spanLines: (chunks) => <span>{chunks}</span>,
+              spanLines: (chunks) => (
+                <Link href={`tel:+${chunks}`}>{chunks}</Link>
+              ),
             })}
           </p>
           <div>{t("visaAccepted")}</div>


### PR DESCRIPTION
# 🩺 Problème
L'utilisateur ne peut pas appeler directement en cliquant sur le numéro de téléphone présent dans la modal sur la page d'accueil, le pied de page et la page contact.
De plus, il doit changer de page lorsqu'il est sur la page du menu pour appeler le restaurant.

# 💊 Proposition
Pour améliorer l'expérience, ajout des éléments "anchor" sur la modal, la page contact et le pied de page et création d'un composant click-to-call sur la page menu pour faciliter la commande.

# ✅ Checklist

- [ ] Ajout de tests unitaires
- [ ] Self-review du code
- [ ] Revue Sonarcloud (fix errors & warnings)
- [ ] Vérifier l'accessibilité (si frontend)
- [ ] Ecrire et assigner la tâche de validation (tests fonctionnels) à quelqu'un du Produit (juste avant de merge la PR)
