### PR TITLE
feat: updating workflows

### DIFF
--- a/.github/workflows/cleanup-preview.yml
+++ b/.github/workflows/cleanup-preview.yml
@@ -1,0 +1,15 @@
+name: Clean up Preview Deployment
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  delete-preview:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete Neon Branch
+        uses: neondatabase/delete-branch-action@v3.1.3
+        with:
+          project_id: ${{ secrets.NEON_PROJECT_ID }}
+          branch: preview/pr-${{ github.event.number }}-${{ github.event.pull_request.head.ref }}
+          api_key: ${{ secrets.NEON_API_KEY }}

--- a/.github/workflows/deploy-feature.yml
+++ b/.github/workflows/deploy-feature.yml
@@ -38,6 +38,8 @@ jobs:
           echo DATABASE_URL=${{ steps.create-branch.outputs.db_url_with_pooler }} >> .env
           echo DIRECT_URL=${{ steps.create-branch.outputs.db_url }} >> .env
 
+          yarn install
+
           npx prisma generate
           npx prisma migrate deploy
 


### PR DESCRIPTION
# 🩺 Problème
- Prisma est mis à jour à chaque nouvelle version
- La branche preview de neon n'est pas supprimée lors du merge

# 💊 Proposition
- Ajout de la commande `yarn install` avant la migration pour conserver la version de prisma dans le package.json
- Ajout du workflow de suppression de la branche enfant de neon

# ✅ Checklist

- [ ] Ajout de tests unitaires
- [ ] Self-review du code
- [ ] Revue Sonarcloud (fix errors & warnings)
- [ ] Vérifier l'accessibilité (si frontend)
- [ ] Ecrire et assigner la tâche de validation (tests fonctionnels) à quelqu'un du Produit (juste avant de merge la PR)
